### PR TITLE
Add keep-ratio option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ See `requirements.txt` for detailed dependencies.
 When running from the command line, the LSTM model automatically uses a
 long-silence threshold derived from the training data. You can override
 this by passing `--duration-threshold` with a custom number of seconds.
+Use `--keep-ratio` to specify what fraction of each cut silence should remain
+in the saved transcript.
 
 ## Transcript Format
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -45,6 +45,8 @@ When using CLI mode with LSTM processing:
 - `--batch-size`: Training batch size (default: 8)
 - `--duration-threshold`: Override the model's long-silence threshold
   (in seconds). By default the threshold is learned from training data.
+- `--keep-ratio`: Fraction of each cut silence to keep when saving the
+  processed transcript (default: 0.5)
 
 ## Example Workflows
 

--- a/gui_wrapper.py
+++ b/gui_wrapper.py
@@ -310,6 +310,20 @@ class PytorchSilencerApp(QMainWindow):
         threshold_layout.addWidget(threshold_label)
         threshold_layout.addWidget(self.threshold_spinner)
         threshold_layout.addStretch()
+
+        # Keep ratio
+        keep_group = QGroupBox("Keep Ratio")
+        keep_layout = QHBoxLayout(keep_group)
+
+        keep_label = QLabel("Keep Ratio:")
+        self.keep_ratio_spinner = QDoubleSpinBox()
+        self.keep_ratio_spinner.setRange(0.0, 1.0)
+        self.keep_ratio_spinner.setSingleStep(0.05)
+        self.keep_ratio_spinner.setValue(0.5)
+
+        keep_layout.addWidget(keep_label)
+        keep_layout.addWidget(self.keep_ratio_spinner)
+        keep_layout.addStretch()
         
         # Process button
         button_layout = QHBoxLayout()
@@ -328,12 +342,13 @@ class PytorchSilencerApp(QMainWindow):
         self.process_log_viewer.setReadOnly(True)
         
         log_layout.addWidget(self.process_log_viewer)
-        
+
         # Add all components to main layout
         layout.addWidget(model_group)
         layout.addWidget(input_group)
         layout.addWidget(output_group)
         layout.addWidget(threshold_group)
+        layout.addWidget(keep_group)
         layout.addLayout(button_layout)
         layout.addWidget(log_group, 1)  # Give log more stretch
 
@@ -564,6 +579,7 @@ class PytorchSilencerApp(QMainWindow):
         output_path = f"{base}_{timestamp}{ext}"
         self.output_transcript_field.setText(output_path)
         threshold = self.threshold_spinner.value()
+        keep_ratio = self.keep_ratio_spinner.value()
         
         # Clear log
         self.process_log_viewer.clear()
@@ -578,7 +594,8 @@ class PytorchSilencerApp(QMainWindow):
             "--model", model_path,
             "--input", input_path,
             "--output", output_path,
-            "--threshold", str(threshold)
+            "--threshold", str(threshold),
+            "--keep-ratio", str(keep_ratio),
         ]
         
         # Run command in thread


### PR DESCRIPTION
## Summary
- allow specifying how much of each cut silence remains
- add `--keep-ratio` to CLI and GUI
- document keep-ratio in README and USAGE

## Testing
- `python -m py_compile lstm_demo.py gui_wrapper.py`

------
https://chatgpt.com/codex/tasks/task_b_684bf429580c832a9788b3133379b051