### PR TITLE
Remember paths between sessions and default video name

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ See `requirements.txt` for detailed dependencies.
    ```
    pip install -r requirements.txt
    ```
+   This installs all dependencies, including **moviepy** which is
+   needed for the video cutting feature.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- persist commonly used file paths in `last_paths.json`
- load saved paths on startup and reuse them
- set output video name to `<input>_videocut.mp4`
- run `save_paths` whenever a location is chosen
- document moviepy install requirement in the README

## Testing
- `python -m py_compile gui_wrapper.py`
- `pytest -q`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_b_684c7e202818832aaaaf7e64ee52aba3