### PR TITLE
Update crossfade logic for specified silence

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,11 @@ The output adds `[SILENCE-CUT]` markers to indicate silences that should be remo
 ```
 
 When a duration is included, e.g. `[SILENCE-CUT 0.68s]`, the number
-represents how much of that silence should remain. The Audio Silencer
-removes the rest from the middle of the silence so the cut is less
-noticeable ("middle-out" style).
+represents how much of that silence should remain **after** the edit.
+The Audio Silencer removes the rest from the middle of the silence and
+uses that remaining duration as the crossfade length, so in this example
+only `0.68` seconds of audio/video are blended between the surrounding
+segments.
 
 ## LSTM Model Architecture
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -97,5 +97,6 @@ Then use the interface to:
 2. Process transcripts (Prediction tab)
 3. Cut video using processed transcript (Audio Silencer tab)
    - If the transcript includes markers like `[SILENCE-CUT 0.68s]`, the number
-     indicates how much of that silence should remain. The silencer removes the
-     rest from the middle of the gap for smoother results.
+     specifies the crossfade length. The remaining silence is trimmed from the
+     middle of the gap so only that amount (e.g. `0.68` seconds) is blended
+     between the neighbouring clips.

--- a/audio_silencer.py
+++ b/audio_silencer.py
@@ -86,7 +86,9 @@ def cut_video(video_path: str, transcript_path: str, output_path: str) -> None:
             cut_dur = seg_dur - remain
             keep_start = start + cut_dur / 2
             keep_end = end - cut_dur / 2
-            cf = 0.0
+            # Use the specified remaining duration as the crossfade length so
+            # that this amount of audio/video is preserved after cutting.
+            cf = remain
         else:
             keep_start = start + 0.1 * seg_dur
             keep_end = end - 0.1 * seg_dur


### PR DESCRIPTION
## Summary
- crossfade using the provided remaining silence duration
- clarify how `[SILENCE-CUT <time>]` works in README and USAGE docs

## Testing
- `python -m py_compile audio_silencer.py gui_wrapper.py data_processor.py silence_model.py anomaly_model.py autoencoder_demo.py lstm_demo.py`
- `python audio_silencer.py --help`

------
https://chatgpt.com/codex/tasks/task_b_684d81e72018832a9f0550c6f0df5934