### PR TITLE
Improve dynamic silence cutting

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ See `requirements.txt` for detailed dependencies.
 
 ## Usage
 
-1. Run the application:
+1. Run the application (GUI wrapper):
    ```
-   python app.py
+   python gui_wrapper.py
    ```
+   The GUI is the primary interface for training models and processing
+   transcripts.
 
 2. **Training**:
    - Navigate to the "Training" tab
@@ -116,6 +118,12 @@ Audio Silencer trims this amount from the middle of the silence and uses
 the leftover portion as the crossfade length. In this example, `0.68`
 seconds are cut while the rest is blended between the surrounding
 segments.
+
+The exact amount of silence removed for each gap is determined by the
+LSTM model. Instead of using a static value, the model predicts how much
+of the detected pause is excessive based on the surrounding words. The
+more confident the model is that a silence should be shortened, the more
+of that gap will be removed.
 
 ## LSTM Model Architecture
 


### PR DESCRIPTION
## Summary
- add `predict_scores` and `predict_with_scores` helpers
- compute cut durations using prediction confidence
- document GUI entry point and dynamic trimming behaviour

## Testing
- `python -m py_compile silence_model.py lstm_demo.py gui_wrapper.py audio_silencer.py data_processor.py autoencoder_demo.py anomaly_model.py`
- `python lstm_demo.py -h` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_684dbbf8f824832a835725f51ddebc95