### PR TITLE
Support good/bad training sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ this by passing `--duration-threshold` with a custom number of seconds.
 The `--keep-ratio` option is now ignored because the model outputs the exact
 amount of silence to remove for every gap.
 
+### Training with Good and Bad Examples
+
+To teach the model the difference between well-timed pauses and awkward ones you
+can provide both a directory of **good** transcripts and a directory of
+**bad** transcripts. Silences from the good set are treated as positive examples
+while silences from the bad set are negatives:
+
+```bash
+python lstm_demo.py train --good path/to/good --bad path/to/bad --model models/silence_model.pt
+```
+
+If `--bad` is omitted the script falls back to the duration-based model which
+learns how long each pause should be based only on the good data.
+
 ## Transcript Format
 
 The application expects transcripts in the following format:


### PR DESCRIPTION
## Summary
- allow training on separate 'good' and 'bad' transcript folders
- add `load_labeled_sequences` helper for combined datasets
- update `lstm_demo.py` to train a classifier when `--bad` is supplied
- document the new workflow in `README.md`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684e8df51ed0832ab446ce6e274e76e3