### PR TITLE
Fix missing imports in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,9 @@ import io
 import contextlib
 from typing import List, Tuple, Optional
 
+import pickle
+from sklearn.preprocessing import StandardScaler
+
 import pandas as pd
 import numpy as np
 import torch


### PR DESCRIPTION
## Summary
- add missing imports for pickle and scikit‑learn's StandardScaler

## Testing
- `python -m py_compile main.py`
- `pip install -q scikit-learn` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_b_684ea86ea290832ab51d97a69dab0174